### PR TITLE
Correct strchr behaviour when c==0x00

### DIFF
--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -25,11 +25,11 @@ class strchr(angr.SimProcedure):
         if self.state.solver.symbolic(s_strlen.ret_expr):
             l.debug("symbolic strlen")
             # TODO: more constraints here to make sure we don't search too little
-            max_sym = min(self.state.solver.max_int(s_strlen.ret_expr), self.state.libc.max_symbolic_strchr)
+            max_sym = min(self.state.solver.max_int(s_strlen.ret_expr)+1, self.state.libc.max_symbolic_strchr)
             a, c, i = self.state.memory.find(s_addr, c, s_strlen.max_null_index, max_symbolic_bytes=max_sym, default=0)
         else:
             l.debug("concrete strlen")
-            max_search = self.state.solver.eval(s_strlen.ret_expr)
+            max_search = self.state.solver.eval(s_strlen.ret_expr)+1
             a, c, i = self.state.memory.find(s_addr, c, max_search, default=0, chunk_size=chunk_size)
 
         if len(i) > 1:


### PR DESCRIPTION
 From man 3 strchr:

> ... The terminating null byte is considered part of the string, so that if  c  is  specified  as '\0', these functions return a pointer to the terminator.

Could also optimize to always return s_addr+strlen when c == 0x00, but that would be a premature optimization from my part.